### PR TITLE
marshmallow 3 compat

### DIFF
--- a/marshmallow_peewee/compat.py
+++ b/marshmallow_peewee/compat.py
@@ -1,0 +1,18 @@
+try:
+    from marshmallow.compat import OrderedDict, PY2, string_types, with_metaclass
+except ImportError:
+    from collections import OrderedDict
+    PY2 = False
+    string_types = (str,)
+
+    # From six
+    def with_metaclass(meta, *bases):
+        """Create a base class with a metaclass."""
+        # This requires a bit of explanation: the basic idea is to make a dummy
+        # metaclass for one level of class instantiation that replaces itself with
+        # the actual metaclass.
+        class metaclass(meta):  # noqa
+
+            def __new__(cls, name, this_bases, d):
+                return meta(name, bases, d)
+        return type.__new__(metaclass, 'temporary_class', (), {})

--- a/marshmallow_peewee/convert.py
+++ b/marshmallow_peewee/convert.py
@@ -1,8 +1,19 @@
 import peewee as pw
-from marshmallow import fields, validate as ma_validate
+from marshmallow import ValidationError, fields
+from marshmallow import validate as ma_validate
 
 from .compat import OrderedDict
 from .fields import ForeignKey
+
+
+def convert_value_validate(converter):
+    def _convert_value_validate(value):
+        try:
+            converter(value)
+        except Exception as e:
+            raise ValidationError(e.message)
+
+    return _convert_value_validate
 
 
 class ModelConverter(object):
@@ -48,11 +59,19 @@ class ModelConverter(object):
             'allow_none': field.null,
             'attribute': field.name,
             'required': not field.null and field.default is None,
-            'validate': field.python_value,
+            'validate': [convert_value_validate(field.python_value)],
         }
 
         if field.default is not None:
             params['default'] = field.default
+
+        if field.choices is not None:
+            choices = []
+            labels = []
+            for c in field.choices:
+                choices.append(c[0])
+                labels.append(c[1])
+            params['validate'].append(ma_validate.OneOf(choices, labels))
 
         # use first "known" field class from field class mro
         # so that extended field classes get converted correctly
@@ -78,7 +97,7 @@ class ModelConverter(object):
     convert_BigAutoField = convert_AutoField
 
     def convert_CharField(self, field, validate=None, **params):
-        validate = ma_validate.Length(max=field.max_length)
+        validate += [ma_validate.Length(max=field.max_length)]
         return fields.String(validate=validate, **params)
 
     def convert_BooleanField(self, field, validate=None, **params):

--- a/marshmallow_peewee/fields.py
+++ b/marshmallow_peewee/fields.py
@@ -1,7 +1,8 @@
 import datetime as dt
 
 from marshmallow import fields
-from marshmallow.compat import PY2, string_types
+
+from .compat import PY2, string_types
 
 
 class Timestamp(fields.Field):

--- a/marshmallow_peewee/schema.py
+++ b/marshmallow_peewee/schema.py
@@ -1,15 +1,15 @@
 import marshmallow as ma
 import peewee as pw
-from marshmallow.compat import with_metaclass
 
+from .compat import with_metaclass
 from .convert import ModelConverter
 from .fields import Related
 
 
 class SchemaOpts(ma.SchemaOpts):
 
-    def __init__(self, meta):
-        super(SchemaOpts, self).__init__(meta)
+    def __init__(self, meta, **kwargs):
+        super(SchemaOpts, self).__init__(meta, **kwargs)
         self.model = getattr(meta, 'model', None)
         self.dump_only_pk = getattr(meta, 'dump_only_pk', True)
         if self.model and not issubclass(self.model, pw.Model):


### PR DESCRIPTION
Added support for marshmallow 3 while leaving backwards compatibility.
Added BigAutoField support in converter. Also, converter now properly converts subclassed fields.