### PR TITLE
Support EnumField implementation by Enum class in Python.

### DIFF
--- a/marshmallow_peewee/convert.py
+++ b/marshmallow_peewee/convert.py
@@ -61,8 +61,8 @@ class ModelConverter(object):
             choices = []
             labels = []
             for c in field.choices:
-                choices.append(c[0])
-                labels.append(c[1])
+                choices.append(c.value)
+                labels.append(c.name)
             params['validate'].append(ma_validate.OneOf(choices, labels))
 
         # use first "known" field class from field class mro

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 marshmallow     >= 2.15.0
 peewee          >= 3.3.0
+enum34          >= 1.1.6


### PR DESCRIPTION
Because peewee doesn't provide EnumField, people usually implement this field themself through the Enum class in python. 
But Enum object dose not support  support indexing, so I have made some adjustments, and you can review it. If you have any questions, please let me know. @klen 
