### PR TITLE
Support for custom peewee fields.

### DIFF
--- a/marshmallow_peewee/convert.py
+++ b/marshmallow_peewee/convert.py
@@ -47,7 +47,6 @@ class ModelConverter(object):
         return result
 
     def convert_field(self, field):
-                validate = [convert_value_validate(field.python_value)]
         params = {
             'allow_none': field.null,
             'attribute': field.name,

--- a/marshmallow_peewee/convert.py
+++ b/marshmallow_peewee/convert.py
@@ -47,11 +47,18 @@ class ModelConverter(object):
         return result
 
     def convert_field(self, field):
+        pw_fields = [x[0] for x in self.TYPE_MAPPING]
+        for f in pw_fields:
+            if isinstance(fields, f):
+                validate = [convert_value_validate(field.python_value)]
+                break
+        else:
+            validate = []
         params = {
             'allow_none': field.null,
             'attribute': field.name,
             'required': not field.null and field.default is None,
-            'validate': [convert_value_validate(field.python_value)],
+            'validate': validate,
         }
 
         if field.default is not None:

--- a/marshmallow_peewee/convert.py
+++ b/marshmallow_peewee/convert.py
@@ -47,18 +47,12 @@ class ModelConverter(object):
         return result
 
     def convert_field(self, field):
-        pw_fields = [x[0] for x in self.TYPE_MAPPING]
-        for f in pw_fields:
-            if isinstance(fields, f):
                 validate = [convert_value_validate(field.python_value)]
-                break
-        else:
-            validate = []
         params = {
             'allow_none': field.null,
             'attribute': field.name,
             'required': not field.null and field.default is None,
-            'validate': validate,
+            'validate': [convert_value_validate(field.db_value)],
         }
 
         if field.default is not None:


### PR DESCRIPTION
Sometimes peopel will customize some peewee fields. 
In my case, I need an AESField that will be able to encrypt when I'm in the database and decrypt when I'm pulling content out of the database.
But in the original validation, the decrypted value is passed to field-python_value again, and the field was lost during deserialization. 
So I did some processing to skip validation for fields that are not native to peewee. 
you can review it. If you have any questions, please let me know. @klen 