### PR TITLE
Add `StringRelatedField`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,29 @@ For ``Marshmallow<3``/``Python<3`` please use ``Marshmallow-Peewee<3``.
     assert isinstance(result, User)
     assert isinstance(result.role, Role)
 
+
+    class UserSchema(ModelSchema):
+
+        role = StringRelatedField(deserialize=deserialize_role)
+
+        class Meta:
+            model = User
+
+    result = UserSchema().dump(user)
+    print(result)
+    # {'active': True,
+    #  'created': '2016-03-29T15:30:32.767483+00:00',
+    #  'id': 1,
+    #  'name': 'Mike',
+    #  'rating': 0,
+    #  'role': 'user',
+    #  'title': None}
+
+    result = UserSchema().load(result)
+    assert isinstance(result, User)
+    assert isinstance(result.role, str)
+
+
 .. _contents:
 
 .. contents::
@@ -114,7 +137,7 @@ Installation
 .. note::
 
     Marshmallow-Peewee>=2.0.0 supports only Peewee>=3.0.0. For Peewee<3.0.0
-    please use Marhmallow-Peewee==1.2.7
+    please use Marshmallow-Peewee==1.2.7
 
 .. _usage:
 

--- a/marshmallow_peewee/__init__.py
+++ b/marshmallow_peewee/__init__.py
@@ -3,4 +3,4 @@ __project__ = "Marshmallow-Peewee"
 __version__ = "3.0.0"
 
 from .schema import ModelSchema # noqa
-from .fields import Timestamp, MSTimestamp, Related, ForeignKey # noqa
+from .fields import Timestamp, MSTimestamp, Related, ForeignKey, StringRelatedField # noqa


### PR DESCRIPTION
- Simple implementation of a `djangorestframework` inspired
`StringRelatedField` class
- The field is serializable-only per default
- A callable can be passed in to deserialize the string
- Optionally a `many` kwarg could be added as well


Do you see any way, this could be merged to a 2.x.x branch? I am probably not the only one, stuck with marshmallow 2.x.x for some time, and having a 2.x.x branch that keeps compatibility with marshmallow 2.x but still gets new features could be imho of great value.
